### PR TITLE
Fixed Recaptcha for mentioned forms

### DIFF
--- a/CRM/Campaign/Form/Petition/Signature.php
+++ b/CRM/Campaign/Form/Petition/Signature.php
@@ -583,21 +583,12 @@ class CRM_Campaign_Form_Petition_Signature extends CRM_Core_Form {
       if ($fields) {
         $this->assign($name, $fields);
 
-        $addCaptcha = FALSE;
         foreach ($fields as $key => $field) {
           // if state or country in the profile, create map
           list($prefixName, $index) = CRM_Utils_System::explode('-', $key, 2);
 
           CRM_Core_BAO_UFGroup::buildProfile($this, $field, CRM_Profile_Form::MODE_CREATE, $contactID, TRUE);
           $this->_fields[$key] = $field;
-          // CRM-11316 Is ReCAPTCHA enabled for this profile AND is this an anonymous visitor
-          if ($field['add_captcha'] && !$this->_contactId) {
-            $addCaptcha = TRUE;
-          }
-        }
-
-        if ($addCaptcha) {
-          CRM_Utils_ReCAPTCHA::enableCaptchaOnForm($this);
         }
       }
     }

--- a/CRM/Campaign/Form/Petition/Signature.php
+++ b/CRM/Campaign/Form/Petition/Signature.php
@@ -152,6 +152,22 @@ class CRM_Campaign_Form_Petition_Signature extends CRM_Core_Form {
     return $session->get('userID');
   }
 
+  /**
+   * Get the active UFGroups (profiles) on this form
+   *
+   * @return array
+   */
+  public function getUFGroupIDs() {
+    $ufGroupIDs = [];
+    if (!empty($this->_contactProfileId)) {
+      $ufGroupIDs[] = $this->_contactProfileId;
+    }
+    if (!empty($this->_activityProfileId)) {
+      $ufGroupIDs[] = $this->_activityProfileId;
+    }
+    return $ufGroupIDs;
+  }
+
   public function preProcess() {
     $this->bao = new CRM_Campaign_BAO_Petition();
     $this->_mode = self::MODE_CREATE;

--- a/CRM/Contribute/Form/Contribution/Main.php
+++ b/CRM/Contribute/Form/Contribution/Main.php
@@ -314,12 +314,6 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
       $this->buildComponentForm($this->_id, $this);
     }
 
-    if (\Civi::settings()->get('forceRecaptcha')) {
-      if (!$this->_userID) {
-        CRM_Utils_ReCAPTCHA::enableCaptchaOnForm($this);
-      }
-    }
-
     // Build payment processor form
     CRM_Core_Payment_ProcessorForm::buildQuickForm($this);
 

--- a/CRM/Contribute/Form/Contribution/Main.php
+++ b/CRM/Contribute/Form/Contribution/Main.php
@@ -42,6 +42,30 @@ class CRM_Contribute_Form_Contribution_Main extends CRM_Contribute_Form_Contribu
   protected $_snippet;
 
   /**
+   * Get the active UFGroups (profiles) on this form
+   *
+   * @return array
+   */
+  public function getUFGroupIDs() {
+    $ufGroupIDs = [];
+    if (!empty($this->_values['custom_pre_id'])) {
+      $ufGroupIDs[] = $this->_values['custom_pre_id'];
+    }
+    if (!empty($this->_values['custom_post_id'])) {
+      // custom_post_id can be an array (because we can have multiple for events).
+      // It is handled as array for contribution page as well though they don't support multiple profiles.
+      if (!is_array($this->_values['custom_post_id'])) {
+        $ufGroupIDs[] = $this->_values['custom_post_id'];
+      }
+      else {
+        $ufGroupIDs = array_merge($ufGroupIDs, $this->_values['custom_post_id']);
+      }
+    }
+
+    return $ufGroupIDs;
+  }
+
+  /**
    * Set variables up before form is built.
    */
   public function preProcess() {

--- a/CRM/Contribute/Form/ContributionBase.php
+++ b/CRM/Contribute/Form/ContributionBase.php
@@ -821,13 +821,6 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
   }
 
   /**
-   * Check if ReCAPTCHA has to be added on Contribution form forcefully.
-   */
-  protected function hasToAddForcefully() {
-    return CRM_Utils_ReCAPTCHA::hasToAddForcefully();
-  }
-
-  /**
    * Add onbehalf/honoree profile fields and native module fields.
    *
    * @param int $id

--- a/CRM/Contribute/Form/ContributionBase.php
+++ b/CRM/Contribute/Form/ContributionBase.php
@@ -667,7 +667,6 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
         }
 
         CRM_Core_BAO_Address::checkContactSharedAddressFields($fields, $contactID);
-        $addCaptcha = FALSE;
         // fetch file preview when not submitted yet, like in online contribution Confirm and ThankYou page
         $viewOnlyFileValues = empty($profileContactType) ? [] : [$profileContactType => []];
         foreach ($fields as $key => $field) {
@@ -740,10 +739,6 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
             );
             $this->_fields[$key] = $field;
           }
-          // CRM-11316 Is ReCAPTCHA enabled for this profile AND is this an anonymous visitor
-          if ($field['add_captcha'] && !$this->_userID) {
-            $addCaptcha = TRUE;
-          }
         }
 
         $this->assign($name, $fields);
@@ -753,10 +748,6 @@ class CRM_Contribute_Form_ContributionBase extends CRM_Core_Form {
         }
         elseif (count($viewOnlyFileValues)) {
           $this->assign('viewOnlyFileValues', $viewOnlyFileValues);
-        }
-
-        if ($addCaptcha && !$viewOnly) {
-          CRM_Utils_ReCAPTCHA::enableCaptchaOnForm($this);
         }
       }
     }

--- a/CRM/Event/Form/Registration.php
+++ b/CRM/Event/Form/Registration.php
@@ -537,7 +537,6 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
       $fields = array_diff_key($fields, $fieldsToIgnore);
       CRM_Core_Session::setStatus(ts('Some of the profile fields cannot be configured for this page.'));
     }
-    $addCaptcha = FALSE;
 
     if (!empty($this->_fields)) {
       $fields = @array_diff_assoc($fields, $this->_fields);
@@ -557,19 +556,10 @@ class CRM_Event_Form_Registration extends CRM_Core_Form {
         if ($button == 'skip') {
           $field['is_required'] = FALSE;
         }
-        // CRM-11316 Is ReCAPTCHA enabled for this profile AND is this an anonymous visitor
-        elseif ($field['add_captcha'] && !$contactID) {
-          // only add captcha for first page
-          $addCaptcha = TRUE;
-        }
         CRM_Core_BAO_UFGroup::buildProfile($this, $field, CRM_Profile_Form::MODE_CREATE, $contactID, TRUE);
 
         $this->_fields[$key] = $field;
       }
-    }
-
-    if ($addCaptcha) {
-      CRM_Utils_ReCAPTCHA::enableCaptchaOnForm($this);
     }
   }
 

--- a/CRM/Event/Form/Registration/AdditionalParticipant.php
+++ b/CRM/Event/Form/Registration/AdditionalParticipant.php
@@ -28,6 +28,21 @@ class CRM_Event_Form_Registration_AdditionalParticipant extends CRM_Event_Form_R
   public $additionalParticipantId = NULL;
 
   /**
+   * Get the active UFGroups (profiles) on this form
+   *
+   * @return array
+   */
+  public function getUFGroupIDs() {
+    $ufGroupIDs = [];
+    foreach (['pre', 'post'] as $keys) {
+      if (isset($this->_values['additional_custom_' . $keys . '_id'])) {
+        $ufGroupIDs[] = $this->_values['additional_custom_' . $keys . '_id'];
+      }
+    }
+    return $ufGroupIDs;
+  }
+
+  /**
    * Set variables up before form is built.
    *
    * @return void

--- a/CRM/Event/Form/Registration/Register.php
+++ b/CRM/Event/Form/Registration/Register.php
@@ -129,6 +129,29 @@ class CRM_Event_Form_Registration_Register extends CRM_Event_Form_Registration {
   }
 
   /**
+   * Get the active UFGroups (profiles) on this form
+   *
+   * @return array
+   */
+  public function getUFGroupIDs() {
+    $ufGroupIDs = [];
+    if (!empty($this->_values['custom_pre_id'])) {
+      $ufGroupIDs[] = $this->_values['custom_pre_id'];
+    }
+    if (!empty($this->_values['custom_post_id'])) {
+      // custom_post_id can be an array (because we can have multiple for events).
+      // It is handled as array for contribution page as well though they don't support multiple profiles.
+      if (!is_array($this->_values['custom_post_id'])) {
+        $ufGroupIDs[] = $this->_values['custom_post_id'];
+      }
+      else {
+        $ufGroupIDs = array_merge($ufGroupIDs, $this->_values['custom_post_id']);
+      }
+    }
+    return $ufGroupIDs;
+  }
+
+  /**
    * Set variables up before form is built.
    *
    * @throws \CRM_Core_Exception

--- a/CRM/Mailing/Form/Subscribe.php
+++ b/CRM/Mailing/Form/Subscribe.php
@@ -105,14 +105,6 @@ ORDER BY title";
       $this->addFormRule(['CRM_Mailing_Form_Subscribe', 'formRule']);
     }
 
-    // CRM-11316 Enable ReCAPTCHA for anonymous visitors
-    $session = CRM_Core_Session::singleton();
-    $contactID = $session->get('userID');
-
-    if (!$contactID) {
-      CRM_Utils_ReCAPTCHA::enableCaptchaOnForm($this);
-    }
-
     $this->addButtons([
       [
         'type' => 'next',

--- a/CRM/PCP/Form/PCPAccount.php
+++ b/CRM/PCP/Form/PCPAccount.php
@@ -35,6 +35,19 @@ class CRM_PCP_Form_PCPAccount extends CRM_Core_Form {
    */
   public $_single;
 
+  /**
+   * Get the active UFGroups (profiles) on this form
+   *
+   * @return array
+   */
+  public function getUFGroupIDs() {
+    $ufGroupIDs = [];
+    if (!empty($this->_pageId)) {
+      $ufGroupIDs[] = CRM_PCP_BAO_PCP::getSupporterProfileId($this->_pageId, $this->_component);
+    }
+    return $ufGroupIDs;
+  }
+
   public function preProcess() {
     $session = CRM_Core_Session::singleton();
     $config = CRM_Core_Config::singleton();
@@ -117,21 +130,21 @@ class CRM_PCP_Form_PCPAccount extends CRM_Core_Form {
    * @return void
    */
   public function buildQuickForm() {
-    $id = CRM_PCP_BAO_PCP::getSupporterProfileId($this->_pageId, $this->_component);
-    if (CRM_PCP_BAO_PCP::checkEmailProfile($id)) {
+    $ufGroupID = CRM_PCP_BAO_PCP::getSupporterProfileId($this->_pageId, $this->_component);
+    if (CRM_PCP_BAO_PCP::checkEmailProfile($ufGroupID)) {
       $this->assign('profileDisplay', TRUE);
     }
     $fields = NULL;
     if ($this->_contactID) {
-      if (CRM_Core_BAO_UFGroup::filterUFGroups($id, $this->_contactID)) {
-        $fields = CRM_Core_BAO_UFGroup::getFields($id, FALSE, CRM_Core_Action::ADD);
+      if (CRM_Core_BAO_UFGroup::filterUFGroups($ufGroupID, $this->_contactID)) {
+        $fields = CRM_Core_BAO_UFGroup::getFields($ufGroupID, FALSE, CRM_Core_Action::ADD);
       }
       $this->addFormRule(['CRM_PCP_Form_PCPAccount', 'formRule'], $this);
     }
     else {
-      CRM_Core_BAO_CMSUser::buildForm($this, $id, TRUE);
+      CRM_Core_BAO_CMSUser::buildForm($this, $ufGroupID, TRUE);
 
-      $fields = CRM_Core_BAO_UFGroup::getFields($id, FALSE, CRM_Core_Action::ADD);
+      $fields = CRM_Core_BAO_UFGroup::getFields($ufGroupID, FALSE, CRM_Core_Action::ADD);
     }
 
     if ($fields) {

--- a/CRM/PCP/Form/PCPAccount.php
+++ b/CRM/PCP/Form/PCPAccount.php
@@ -149,7 +149,6 @@ class CRM_PCP_Form_PCPAccount extends CRM_Core_Form {
 
     if ($fields) {
       $this->assign('fields', $fields);
-      $addCaptcha = FALSE;
       foreach ($fields as $key => $field) {
         if (isset($field['data_type']) && $field['data_type'] == 'File') {
           // ignore file upload fields
@@ -157,15 +156,6 @@ class CRM_PCP_Form_PCPAccount extends CRM_Core_Form {
         }
         CRM_Core_BAO_UFGroup::buildProfile($this, $field, CRM_Profile_Form::MODE_CREATE);
         $this->_fields[$key] = $field;
-
-        // CRM-11316 Is ReCAPTCHA enabled for this profile AND is this an anonymous visitor
-        if ($field['add_captcha'] && !$this->_contactID) {
-          $addCaptcha = TRUE;
-        }
-      }
-
-      if ($addCaptcha) {
-        CRM_Utils_ReCAPTCHA::enableCaptchaOnForm($this);
       }
     }
 

--- a/CRM/Profile/Form.php
+++ b/CRM/Profile/Form.php
@@ -271,6 +271,27 @@ class CRM_Profile_Form extends CRM_Core_Form {
   }
 
   /**
+   * Get the active UFGroups (profiles) on this form
+   *
+   * @return array
+   */
+  public function getUFGroupIDs() {
+    if (empty($this->_profileIds)) {
+      $this->_profileIds = $this->get('profileIds');
+    }
+    return $this->_profileIds;
+  }
+
+  /**
+   * Are we using the profile in create mode?
+   *
+   * @return bool
+   */
+  public function getIsCreateMode() {
+    return ($this->_mode == self::MODE_CREATE);
+  }
+
+  /**
    * Pre processing work done here.
    *
    * gets session variables for table name, id of entity in table, type of entity and stores them.

--- a/CRM/Profile/Form.php
+++ b/CRM/Profile/Form.php
@@ -101,8 +101,6 @@ class CRM_Profile_Form extends CRM_Core_Form {
    */
   public $_ruleGroupID = NULL;
 
-  public $_isAddCaptcha = FALSE;
-
   protected $_isPermissionedChecksum = FALSE;
 
   /**
@@ -367,13 +365,12 @@ class CRM_Profile_Form extends CRM_Core_Form {
     }
     $this->_isContactActivityProfile = CRM_Core_BAO_UFField::checkContactActivityProfileType($this->_gid);
 
-    //get values for ufGroupName, captcha and dupe update.
+    //get values for ufGroupName and dupe update.
     if ($this->_gid) {
       $dao = new CRM_Core_DAO_UFGroup();
       $dao->id = $this->_gid;
       if ($dao->find(TRUE)) {
         $this->_isUpdateDupe = $dao->is_update_dupe;
-        $this->_isAddCaptcha = $dao->add_captcha;
         $this->_ufGroup = (array) $dao;
       }
 
@@ -830,7 +827,6 @@ class CRM_Profile_Form extends CRM_Core_Form {
     }
     $this->assign('anonUser', $anonUser);
 
-    $addCaptcha = [];
     $emailPresent = FALSE;
 
     // add the form elements
@@ -856,27 +852,13 @@ class CRM_Profile_Form extends CRM_Core_Form {
         $addToGroupId = $field['add_to_group_id'];
       }
 
-      //build array for captcha
-      if ($field['add_captcha']) {
-        $addCaptcha[$field['group_id']] = $field['add_captcha'];
-      }
-
       if (($name == 'email-Primary') || ($name == 'email-' . ($primaryLocationType ?? ""))) {
         $emailPresent = TRUE;
         $this->_mail = $name;
       }
     }
 
-    // add captcha only for create mode.
     if ($this->_mode == self::MODE_CREATE) {
-      // suppress captcha for logged in users only
-      if ($this->_currentUserID) {
-        $this->_isAddCaptcha = FALSE;
-      }
-      elseif (!$this->_isAddCaptcha && !empty($addCaptcha)) {
-        $this->_isAddCaptcha = TRUE;
-      }
-
       if ($this->_gid) {
         $dao = new CRM_Core_DAO_UFGroup();
         $dao->id = $this->_gid;
@@ -888,14 +870,6 @@ class CRM_Profile_Form extends CRM_Core_Form {
           }
         }
       }
-    }
-    else {
-      $this->_isAddCaptcha = FALSE;
-    }
-
-    //finally add captcha to form.
-    if ($this->_isAddCaptcha) {
-      CRM_Utils_ReCAPTCHA::enableCaptchaOnForm($this);
     }
 
     if ($this->_mode != self::MODE_SEARCH) {

--- a/CRM/Profile/Form.php
+++ b/CRM/Profile/Form.php
@@ -275,7 +275,9 @@ class CRM_Profile_Form extends CRM_Core_Form {
    */
   public function getUFGroupIDs() {
     if (empty($this->_profileIds)) {
-      $this->_profileIds = $this->get('profileIds');
+      $dao = new CRM_Core_DAO_UFGroup();
+	    $dao->id = $this->_gid;
+      $this->_profileIds = (array) $dao;
     }
     return $this->_profileIds;
   }

--- a/ext/recaptcha/CRM/Utils/ReCAPTCHA.php
+++ b/ext/recaptcha/CRM/Utils/ReCAPTCHA.php
@@ -146,7 +146,7 @@ class CRM_Utils_ReCAPTCHA {
         }
         break;
 
-      case 'CRM_Profile_Form':
+      case 'CRM_Profile_Form_Edit':
         // add captcha only for create mode.
         if ($form->getIsCreateMode()) {
           // suppress captcha for logged in users only
@@ -157,7 +157,6 @@ class CRM_Utils_ReCAPTCHA {
         break;
 
       case 'CRM_Event_Form_Registration_Register':
-      case 'CRM_Event_Form_Registration_AdditionalParticipant':
         $button = substr($form->controller->getButtonName(), -4);
         // We show reCAPTCHA for anonymous user if enabled.
         // 'skip' button is on additional participant forms, we only show reCAPTCHA on the primary form.

--- a/ext/recaptcha/recaptcha.php
+++ b/ext/recaptcha/recaptcha.php
@@ -161,4 +161,6 @@ function recaptcha_civicrm_buildForm($formName, &$form) {
           'region' => 'page-body',
         ]);
   }
+
+  CRM_Utils_ReCAPTCHA::checkAndAddCaptchaToForm($formName, $form);
 }


### PR DESCRIPTION
Overview
----------------------------------------
This pull request will fix ReCaptcha for the profile page. The profile page name and the way to fetch UFGroups have been fixed as earlier they were not working. Also, Recaptcha for additional participants of the event page has been removed as it was misbehaving (this page did not support Recaptcha earlier) and now it works well. Since the Recaptcha on the primary form (for the primary participant) is working well, we will not need it on the additional participants form anyway. Have verified that Recaptcha is working as expected (with the same behaviour as earlier) on all the other forms. 

Before
----------------------------------------
_What is the old user-interface or technical-contract (as appropriate)?_
_For optimal clarity, include a concrete example such as a screenshot, GIF ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)), or code-snippet._

After
----------------------------------------
_What changed? What is new old user-interface or technical-contract?_
_For optimal clarity, include a concrete example such as a screenshot, GIF ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)), or code-snippet._

Technical Details
----------------------------------------
_If the PR involves technical details/changes/considerations which would not be manifest to a casual developer skimming the above sections, please describe the details here._

Comments
----------------------------------------
_Anything else you would like the reviewer to note_
